### PR TITLE
Bump artifact actions to v4

### DIFF
--- a/.github/workflows/build-repository.yml
+++ b/.github/workflows/build-repository.yml
@@ -30,7 +30,7 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Store as build artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: built-satis-repository
           path: |


### PR DESCRIPTION
per https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/